### PR TITLE
New Grid API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ All notable changes to this project will be documented in this file. The format 
 [Unreleased]
 ------------
 
-(nothing)
+### Changed
+
+- New `Grid` API: merged `getValues()` into `getCells()`, added `getTiles()`. Both can return a flattened array.
 
 [v0.2.0] - 2018-10-05
 ---------------------

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ $grid = Mozaic::generate($tilesNumber, $columns);
 
 echo '<table>';
 $i = 1;
-foreach ($grid->getValues() as $row) {
+foreach ($grid->getCells() as $row) {
     echo '<tr>';
     foreach ($row as $cell) {
         switch ($cell) {

--- a/demo/table.php
+++ b/demo/table.php
@@ -12,7 +12,7 @@ $grid = Mozaic::generate($tilesNumber, $columns);
 echo '<table>';
 $i = 1;
 
-foreach ($grid->getValues() as $row) {
+foreach ($grid->getCells() as $row) {
     echo '<tr>';
     foreach ($row as $cell) {
         switch ($cell) {

--- a/src/Cell.php
+++ b/src/Cell.php
@@ -17,33 +17,33 @@ class Cell extends Enum
      *
      * @var integer
      */
-    const SMALL = 0;
+    const SMALL = 1;
 
     /**
      * Top cell of a 2-cell-wide tile (1x2) tile.
      *
      * @var integer
      */
-    const TALL_TOP = 1;
+    const TALL_TOP = 2;
 
     /**
      * Bottom cell of a 2-cell-wide tile (1x2) tile.
      *
      * @var integer
      */
-    const TALL_BOTTOM = 2;
+    const TALL_BOTTOM = 3;
 
     /**
      * Left cell of a 2-cell-wide (2x1) tile.
      *
      * @var integer
      */
-    const WIDE_LEFT = 3;
+    const WIDE_LEFT = 4;
 
     /**
      * Right cell of a 2-cell-wide (2x1) tile.
      *
      * @var integer
      */
-    const WIDE_RIGHT = 4;
+    const WIDE_RIGHT = 5;
 }

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -24,4 +24,16 @@ abstract class Enum extends EnumBase
     {
         return $this->getKey();
     }
+
+    /**
+     * Get the value from a mixed value.
+     *
+     * @param mixed $value Enum instance, or anything else.
+     * @return int The enum value if `$value` is an instance of Enum, or
+     * @return mixed The given value unchanged, otherwise.
+     */
+    public static function toValue($value)
+    {
+        return $value instanceof Enum ? $value->getValue() : $value;
+    }
 }

--- a/src/Tile.php
+++ b/src/Tile.php
@@ -50,4 +50,28 @@ class Tile extends Enum
         $this->width = $value === static::WIDE ? 2 : 1;
         $this->height = $value === static::TALL ? 2 : 1;
     }
+
+    /**
+     * Create the Tile corresponding to a cell.
+     *
+     * @param Cell? $cell A cell, or `null`.
+     * @return null If `null` is given.
+     * @return false If the `$cell` is `WIDE_LEFT` or `TALL_BOTTOM`, or
+     * @return Tile The Tile corresponding to the Cell value.
+     */
+    public static function fromCell($cell)
+    {
+        switch (Cell::toValue($cell)) {
+            case null:
+                return null;
+            case Cell::SMALL:
+                return self::SMALL();
+            case Cell::TALL_TOP:
+                return self::TALL();
+            case Cell::WIDE_LEFT:
+                return self::WIDE();
+            default:
+                return false;
+        }
+    }
 }

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -24,7 +24,24 @@ class EnumTest extends TestCase
 
     public function testToStringReturnsConstantName()
     {
-        $this->assertEquals(((string)Letters::A()), 'A');
-        $this->assertEquals(((string)Letters::B()), 'B');
+        $this->assertSame(((string)Letters::A()), 'A');
+        $this->assertSame(((string)Letters::B()), 'B');
+    }
+
+    public function testToValueReturnsNullWhenNullIsGiven()
+    {
+        $this->assertSame(null, Letters::toValue(null));
+    }
+
+    public function testToValueReturnsValueWhenBoolIsGiven()
+    {
+        $this->assertSame(true, Letters::toValue(true));
+        $this->assertSame(false, Letters::toValue(false));
+    }
+
+    public function testToValueReturnsValueWhenEnumIsGiven()
+    {
+        $this->assertSame(Letters::A, Letters::toValue(Letters::A()));
+        $this->assertSame(Letters::B, Letters::toValue(Letters::B()));
     }
 }

--- a/tests/GridTest.php
+++ b/tests/GridTest.php
@@ -245,53 +245,153 @@ class GridTest extends TestCase
         $this->assertEquals('3x5 [1,2,3]', "{$grid}");
     }
 
-    public function testGetCellsReturnsAllCells()
-    {
-        $grid = new Grid(2, 3);
-        $grid->set(0, 0, Tile::TALL());
-        $grid->set(0, 1, Tile::WIDE());
-        $grid->set(1, 2, Tile::SMALL());
-
-        $cells = $grid->getCells();
-        $this->assertEquals(Cell::TALL_TOP(), $cells[0][0]);
-        $this->assertEquals(Cell::TALL_BOTTOM(), $cells[1][0]);
-        $this->assertEquals(Cell::WIDE_LEFT(), $cells[0][1]);
-        $this->assertEquals(Cell::WIDE_RIGHT(), $cells[0][2]);
-        $this->assertEquals(null, $cells[1][1]);
-        $this->assertEquals(Cell::SMALL(), $cells[1][2]);
-    }
-
     public function testGetCellsDoesNotReturnTheOriginalArray()
     {
         $grid = new Grid(2, 3);
         $grid->set(1, 2, Tile::SMALL());
-        $cells = $grid->getCells();
+
+        $cells = $grid->getCells(false, true);
         $cells[1][2] = null;
         $this->assertEquals(Cell::SMALL(), $grid->get(1, 2));
     }
 
-    public function testGetValuesReturnsAllCellValues()
+    public function testGetCellsReturnsTwoDimensionalArrayOfValues()
     {
         $grid = new Grid(2, 3);
         $grid->set(0, 0, Tile::TALL());
         $grid->set(0, 1, Tile::WIDE());
         $grid->set(1, 2, Tile::SMALL());
 
-        $cells = $grid->getValues();
-        $this->assertEquals(Cell::TALL_TOP, $cells[0][0]);
-        $this->assertEquals(Cell::TALL_BOTTOM, $cells[1][0]);
-        $this->assertEquals(Cell::WIDE_LEFT, $cells[0][1]);
-        $this->assertEquals(Cell::WIDE_RIGHT, $cells[0][2]);
-        $this->assertEquals(null, $cells[1][1]);
-        $this->assertEquals(Cell::SMALL, $cells[1][2]);
+        $values = $grid->getCells();
+        $this->assertSame(count($values), 2);
+        $this->assertSame(count($values[0]), 3);
+        $this->assertSame(count($values[1]), 3);
+        $this->assertSame(Cell::TALL_TOP, $values[0][0]);
+        $this->assertSame(Cell::WIDE_LEFT, $values[0][1]);
+        $this->assertSame(Cell::WIDE_RIGHT, $values[0][2]);
+        $this->assertSame(Cell::TALL_BOTTOM, $values[1][0]);
+        $this->assertSame(null, $values[1][1]);
+        $this->assertSame(Cell::SMALL, $values[1][2]);
     }
 
-    public function testGetValuesDoesNotReturnTheOriginalArray()
+    public function testGetCellsReturnsOneDimensionalArrayOfValues()
     {
         $grid = new Grid(2, 3);
+        $grid->set(0, 0, Tile::TALL());
+        $grid->set(0, 1, Tile::WIDE());
         $grid->set(1, 2, Tile::SMALL());
-        $cells = $grid->getValues();
-        $cells[1][2] = null;
-        $this->assertEquals(Cell::SMALL(), $grid->get(1, 2));
+
+        $values = $grid->getCells(true);
+        $this->assertSame(count($values), 2 * 3);
+        $this->assertSame(Cell::TALL_TOP, $values[0]);
+        $this->assertSame(Cell::WIDE_LEFT, $values[1]);
+        $this->assertSame(Cell::WIDE_RIGHT, $values[2]);
+        $this->assertSame(Cell::TALL_BOTTOM, $values[3]);
+        $this->assertSame(null, $values[4]);
+        $this->assertSame(Cell::SMALL, $values[5]);
+    }
+
+    public function testGetCellsReturnsTwoDimensionalArrayOfCells()
+    {
+        $grid = new Grid(2, 3);
+        $grid->set(0, 0, Tile::TALL());
+        $grid->set(0, 1, Tile::WIDE());
+        $grid->set(1, 2, Tile::SMALL());
+
+        $cells = $grid->getCells(false, true);
+        $this->assertSame(count($cells), 2);
+        $this->assertSame(count($cells[0]), 3);
+        $this->assertSame(count($cells[1]), 3);
+        $this->assertEquals(Cell::TALL_TOP(), $cells[0][0]);
+        $this->assertEquals(Cell::WIDE_LEFT(), $cells[0][1]);
+        $this->assertEquals(Cell::WIDE_RIGHT(), $cells[0][2]);
+        $this->assertEquals(Cell::TALL_BOTTOM(), $cells[1][0]);
+        $this->assertEquals(null, $cells[1][1]);
+        $this->assertEquals(Cell::SMALL(), $cells[1][2]);
+    }
+
+    public function testGetCellsReturnsOneDimensionalArrayOfCells()
+    {
+        $grid = new Grid(2, 3);
+        $grid->set(0, 0, Tile::TALL());
+        $grid->set(0, 1, Tile::WIDE());
+        $grid->set(1, 2, Tile::SMALL());
+
+        $cells = $grid->getCells(true, true);
+        $this->assertSame(count($cells), 2 * 3);
+        $this->assertEquals(Cell::TALL_TOP(), $cells[0]);
+        $this->assertEquals(Cell::WIDE_LEFT(), $cells[1]);
+        $this->assertEquals(Cell::WIDE_RIGHT(), $cells[2]);
+        $this->assertEquals(Cell::TALL_BOTTOM(), $cells[3]);
+        $this->assertEquals(null, $cells[4]);
+        $this->assertEquals(Cell::SMALL(), $cells[5]);
+    }
+
+    public function testGetTilesReturnsTwoDimensionalArrayOfValues()
+    {
+        $grid = new Grid(2, 3);
+        $grid->set(0, 0, Tile::TALL());
+        $grid->set(0, 1, Tile::WIDE());
+        $grid->set(1, 2, Tile::SMALL());
+
+        $values = $grid->getTiles();
+        $this->assertSame(count($values), 2);
+        $this->assertSame(count($values[0]), 3);
+        $this->assertSame(count($values[1]), 3);
+        $this->assertSame(Tile::TALL, $values[0][0]);
+        $this->assertSame(Tile::WIDE, $values[0][1]);
+        $this->assertSame(false, $values[0][2]);
+        $this->assertSame(false, $values[1][0]);
+        $this->assertSame(null, $values[1][1]);
+        $this->assertSame(Tile::SMALL, $values[1][2]);
+    }
+
+    public function testGetTilesReturnsOneDimensionalArrayOfValues()
+    {
+        $grid = new Grid(2, 3);
+        $grid->set(0, 0, Tile::TALL());
+        $grid->set(0, 1, Tile::WIDE());
+        $grid->set(1, 2, Tile::SMALL());
+
+        $values = $grid->getTiles(true);
+        $this->assertSame(count($values), 4);
+        $this->assertSame(Tile::TALL, $values[0]);
+        $this->assertSame(Tile::WIDE, $values[1]);
+        $this->assertSame(null, $values[2]);
+        $this->assertSame(Tile::SMALL, $values[3]);
+    }
+
+    public function testGetTilesReturnsTwoDimensionalArrayOfTiles()
+    {
+        $grid = new Grid(2, 3);
+        $grid->set(0, 0, Tile::TALL());
+        $grid->set(0, 1, Tile::WIDE());
+        $grid->set(1, 2, Tile::SMALL());
+
+        $tiles = $grid->getTiles(false, true);
+        $this->assertSame(count($tiles), 2);
+        $this->assertSame(count($tiles[0]), 3);
+        $this->assertSame(count($tiles[1]), 3);
+        $this->assertEquals(Tile::TALL(), $tiles[0][0]);
+        $this->assertEquals(Tile::WIDE(), $tiles[0][1]);
+        $this->assertSame(false, $tiles[0][2]);
+        $this->assertSame(false, $tiles[1][0]);
+        $this->assertSame(null, $tiles[1][1]);
+        $this->assertEquals(Tile::SMALL(), $tiles[1][2]);
+    }
+
+    public function testGetTilesReturnsOneDimensionalArrayOfTiles()
+    {
+        $grid = new Grid(2, 3);
+        $grid->set(0, 0, Tile::TALL());
+        $grid->set(0, 1, Tile::WIDE());
+        $grid->set(1, 2, Tile::SMALL());
+
+        $tiles = $grid->getTiles(true, true);
+        $this->assertSame(count($tiles), 4);
+        $this->assertEquals(Tile::TALL(), $tiles[0]);
+        $this->assertEquals(Tile::WIDE(), $tiles[1]);
+        $this->assertSame(null, $tiles[2]);
+        $this->assertEquals(Tile::SMALL(), $tiles[3]);
     }
 }

--- a/tests/TileTest.php
+++ b/tests/TileTest.php
@@ -3,6 +3,7 @@
 namespace RectangularMozaic\Tests;
 
 use PHPUnit\Framework\TestCase;
+use RectangularMozaic\Cell;
 use RectangularMozaic\Tile;
 
 class TileTest extends TestCase
@@ -37,5 +38,23 @@ class TileTest extends TestCase
         $this->assertEquals(1, Tile::SMALL()->height);
         $this->assertEquals(2, Tile::TALL()->height);
         $this->assertEquals(1, Tile::WIDE()->height);
+    }
+
+    public function testFromCellReturnsNullWhenNullIsGiven()
+    {
+        $this->assertSame(null, Tile::fromCell(null));
+    }
+
+    public function testFromCellReturnsTileWhenStartCellIsGiven()
+    {
+        $this->assertEquals(Tile::SMALL(), Tile::fromCell(Cell::SMALL()));
+        $this->assertEquals(Tile::TALL(), Tile::fromCell(Cell::TALL_TOP()));
+        $this->assertEquals(Tile::WIDE(), Tile::fromCell(Cell::WIDE_LEFT()));
+    }
+
+    public function testFromCellReturnsFalseWhenEndCellIsGiven()
+    {
+        $this->assertEquals(false, Tile::fromCell(Cell::TALL_BOTTOM()));
+        $this->assertEquals(false, Tile::fromCell(Cell::WIDE_RIGHT()));
     }
 }


### PR DESCRIPTION
New Grid API
==========

## Changed `getCells()` signature

```php
getCells(bool $flatten = false, bool $raw = false)
```

- `Grid::getCells()` becomes `Grid::getCells(false, true)`
- `Grid::getValues()` becomes `Grid::getCells()`
- Added the possibility possibility to return a flattened array.

## Added `getTiles()`:

```php
getTiles(bool $flatten = false, bool $raw = false)
```
